### PR TITLE
fix(version): update the module with semantic import versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aeternity/aepp-sdk-go
+module github.com/aeternity/aepp-sdk-go/v4
 
 require (
 	github.com/BurntSushi/toml v0.3.0 // indirect


### PR DESCRIPTION
the go get command doesnt work as expected due to the missing value in the module definition